### PR TITLE
chartBuilder - a component that associates components with the chartLayout

### DIFF
--- a/components/utilities/chartBuilder.js
+++ b/components/utilities/chartBuilder.js
@@ -1,0 +1,98 @@
+(function(d3, fc) {
+    'use strict';
+
+    /**
+    * The chart builder makes it easier to constructs charts from a number of D3FC or D3 components. It
+    * adapts a chartLayout (which is responsible for creating a suitable SVG structure for a chart), and allows
+    * you to associate components (axes, series, etc ...) with the chart. The chart builder
+    * is responsible for associating data with the components, setting the ranges of the scales and updating
+    * the components when the chart needs to be re-drawn.
+    *
+    * @type {object}
+    * @memberof fc.utilities
+    * @class fc.utilities.chartBuilder
+    */
+    fc.utilities.chartBuilder = function(chartLayout) {
+
+        // the components that have been added to the chart.
+        var plotAreaComponents = [];
+        var axes = {};
+
+        // the selection that this chart is associated with
+        var callingSelection;
+
+        var chartBuilder = function(selection) {
+            callingSelection = selection;
+            selection.call(chartLayout);
+        };
+
+        /**
+         * Adds a number of components to the chart plot area. The chart layout is responsible for
+         * rendering these components via the render function.
+         *
+         * @memberof fc.utilities.chartBuilder#
+         * @method addToPlotArea
+         * @param  {array} components an array of components to add to the plot area
+         */
+        chartBuilder.addToPlotArea = function(components) {
+            plotAreaComponents = plotAreaComponents.concat(components);
+        };
+
+        /**
+         * Provides the data that will be joined with the plot area selection, and as a result
+         * is the data used by components that are associated with the ploa area.
+         *
+         * @memberof fc.utilities.chartBuilder#
+         * @method setData
+         * @param  {array} data the data to associate with the plot area
+         */
+        chartBuilder.setData = function(data) {
+            chartLayout.getPlotArea().datum(data);
+        };
+
+        /**
+         * Sets the chart axis with the given orientation. The chart builder is responsible for setting
+         * the range of this axis and rendering it via the render function.
+         *
+         * @memberof fc.utilities.chartBuilder#
+         * @method setAxis
+         * @param  {string} orientation The orientation of the axis container
+         * @param  {object} axis a D3 or D3FC axis component
+         */
+        chartBuilder.setAxis = function(orientation, axis) {
+            axes[orientation] = axis;
+        };
+
+        /**
+         * Renders all of the components associated with this chart. During the render process
+         * the axes have their scales set to an appropriate value.
+         *
+         * @memberof fc.utilities.chartBuilder#
+         * @method render
+         */
+        chartBuilder.render = function() {
+            callingSelection.call(chartLayout);
+
+            // call each of the axis components with the axis selection
+            for (var axisOrientation in axes) {
+                if (axes.hasOwnProperty(axisOrientation)) {
+                    var axisContainer = chartLayout.getAxisContainer(axisOrientation);
+                    var axis = axes[axisOrientation];
+                    if (axisOrientation === 'top' || axisOrientation === 'bottom') {
+                        axis.scale().range([0, chartLayout.getPlotAreaWidth()]);
+                    } else {
+                        axis.scale().range([chartLayout.getPlotAreaHeight(), 0]);
+                    }
+                    axisContainer.call(axis);
+                }
+            }
+
+            // call each of the plot area components
+            plotAreaComponents.forEach(function(component) {
+                chartLayout.getPlotArea().call(component);
+            });
+        };
+
+        return chartBuilder;
+    };
+}(d3, fc));

--- a/components/utilities/chartLayout.js
+++ b/components/utilities/chartLayout.js
@@ -64,12 +64,6 @@
         // The elements created for the chart
         var chartElements = {};
 
-        // components that have been added to the plot area.
-        var plotAreaComponents = [];
-
-        // the selection that was originally used to construct the layout
-        var callingSelection;
-
         /**
          * Constructs a new instance of the chartLayout component.
          *
@@ -91,9 +85,6 @@
          * @param {selection} selection a D3 selection
          */
         var chartLayout = function(selection) {
-
-            callingSelection = selection;
-
             // Select the first element in the selection
             // If the selection contains more than 1 element,
             // only the first will be used, the others will be ignored
@@ -421,63 +412,6 @@
          */
         chartLayout.getAxisContainer = function(orientation) {
             return chartElements.axisContainer[orientation].selection;
-        };
-
-        /**
-         * Adds a number of components to the chart plot area. The chart layout is responsible for
-         * rendering these components via the render function.
-         *
-         * @memberof fc.utilities.chartLayout#
-         * @method addToPlotArea
-         * @param  {array} components an array of components to add to the plot area
-         */
-        chartLayout.addToPlotArea = function(components) {
-            plotAreaComponents = plotAreaComponents.concat(components);
-        };
-
-        /**
-         * Sets the chart axis with the given orientation. The chart layout is responsible for setting
-         * the range of this axis and rendering it via the render function.
-         *
-         * @memberof fc.utilities.chartLayout#
-         * @method addToPlotArea
-         * @param  {string} orientation The orientation of the axis container
-         * @param  {object} axis a D3 or D3FC axis component
-         */
-        chartLayout.setAxis = function(orientation, axis) {
-            chartElements.axisContainer[orientation].axis = axis;
-        };
-
-        /**
-         * Renders all of the components associated with this chart. During the render process
-         * the axes have their scales set to an appropriate value.
-         *
-         * @memberof fc.utilities.chartLayout#
-         * @method render
-         */
-        chartLayout.render = function() {
-            callingSelection.call(chartLayout);
-
-            // call each of the axis components with the axis selection
-            for (var axisContainerName in chartElements.axisContainer) {
-                if (chartElements.axisContainer.hasOwnProperty(axisContainerName)) {
-                    var axisContainer = chartElements.axisContainer[axisContainerName];
-                    if (axisContainer.hasOwnProperty('axis')) {
-                        var axis = axisContainer.axis;
-                        if (axisContainerName === 'top' || axisContainerName === 'bottom') {
-                            axis.scale().range([0, chartLayout.getPlotAreaWidth()]);
-                        } else {
-                            axis.scale().range([chartLayout.getPlotAreaHeight(), 0]);
-                        }
-                        axisContainer.selection.call(axis);
-                    }
-                }
-            }
-
-            // call each of the plot area components
-            plotAreaComponents.forEach(function(component) {
-                chartLayout.getPlotArea().call(component);
-            });
         };
 
         return chartLayout;


### PR DESCRIPTION
Currently resizing the chart, or updating the data, requires quite a lot of structural code:

https://github.com/ScottLogic/d3-financial-components/blob/gh-pages/getting-started.md#rendering-dynamic-charts

My suggestion is to use our chartLayout component to manage the axes, series and any other components that make up a chart.

In order to render a chart, you construct axes, scales, series and add these to the layout. It is then responsible for setting the axis/scale ranges and invoking 'call' on each component.

I like the way that the components still follow the D3 pattern and remain unchanged. Furthermore, it should be possible to wrap up the resize logic so that a chart layout can resize itself automatically.

Here's a chart that supports re-sizing with my changes:

```
// create the chart layout
var chartLayout = fc.utilities.chartLayout();

// Render the initial layout
d3.select('#structured-chart')
    .call(chartLayout);

// Create some data
var startDate = new Date(2014, 1, 1),
    dayCount = 100;
var gsData = fc.utilities.dataGenerator()
    .seedDate(startDate)
    .generate(dayCount);

// Create scales
var xScale = fc.scale.dateTime() 
    .domainFromValues(gsData, ['date']);
var yScale = fc.scale.linear()
    .domainFromValues(gsData, ['low', 'high']);

// Create axes
var bottomAxis = d3.svg.axis()
    .scale(xScale)
    .orient('bottom')
    .ticks(10);
var leftAxis = d3.svg.axis()
    .scale(yScale)
    .orient('left')
    .ticks(5);

// Create some series
var ohlc = fc.series.ohlc()
    .xScale(xScale)
    .yScale(yScale);
var bollinger = fc.indicators.bollingerBands()
    .xScale(xScale)
    .yScale(yScale);

// add gridlines
var gridlines = fc.scale.gridlines()
    .xScale(xScale)
    .yScale(yScale);

// ############### New code below

// Add axis to the chartLayout. The layout is now responsible
// for setting the range of the scales associated with each axis
chartLayout.addAxisToContainer('bottom', bottomAxis);
chartLayout.addAxisToContainer('left', leftAxis);

// Add plot area components
chartLayout.addComponentsToPlotArea([ohlc, gridlines, bollinger]);

// Bind the data
chartLayout.getPlotArea()
    .datum(gsData)

function renderComponents() {
  // Render the chart, this ultimately involves invoking the 'call' method on the
  // various selections for the components added above
  chartLayout.render();
}

// perform an initial render
renderComponents();

// handle resize events, telling the chart to re-render
d3.select(window).on('resize', renderComponents); 
```



