### PR TITLE
Comparison series updates

### DIFF
--- a/components/fc.js
+++ b/components/fc.js
@@ -20,10 +20,17 @@ window.fc = {
      * @namespace fc.scale
      */
     scale: {},
+    /**
+     * Components which plot elements in 2 dimensional space using specified x and y scales.
+     * @namespace fc.series
+     */
     series: {},
+    /**
+     * @namespace fc.tools
+     */
     tools: {},
     /**
-     * Utility components to shorted long winded implementations of common operations.
+     * Utility components to shorten long winded implementations of common operations.
      * Also includes components for mock data generation and layout.
      *
      * @namespace fc.utilities

--- a/components/series/series.css
+++ b/components/series/series.css
@@ -16,6 +16,7 @@
 
 /* Comparison Styles */
 .comparison-series .line {
+    vector-effect: non-scaling-stroke;
     stroke: #000;
     fill: none;
 }


### PR DESCRIPTION
- Removed ordinal colour scale (use css instead)
- No longer have to specify series names. Data input is now an array of data arrays.
- Configurable x and y values using valueAccessor #130 #105 
- Like d3 brush / axis, store element specific state on `__chart__`
  This allows for using a single instance of the component to create multiple charts which are independently interactive on zoom.
- Add JSDoc. Closes #28 