### PR TITLE
chartLayout no longer data-joins the plot area

### DIFF
--- a/components/utilities/chartLayout.js
+++ b/components/utilities/chartLayout.js
@@ -189,11 +189,15 @@
             plotAreaBackground.exit().remove();
 
             // Create plot area, using the clipping path
-            var plotArea = chart.selectAll('g.plotArea').data(dummyData);
-            plotArea.enter().append('g');
-            plotArea.attr('clip-path', 'url(#' + plotAreaClipId + ')')
-                .classed('plotArea', true);
-            plotArea.exit().remove();
+            // NOTE: We do not use a data-join to 'dummy data' here, because it is expected that the
+            // user (or chartBuilder) will want to data-join the plotArea with their own data in order
+            // that it is inherited by the series within the chart
+            var plotArea = chart.selectAll('g.plotArea');
+            if (plotArea.empty()) {
+                plotArea = chart.append('g')
+                    .attr('clip-path', 'url(#' + plotAreaClipId + ')')
+                    .attr('class', 'plotArea');
+            }
 
             // Add selections to the chart elements object for the getters
             chartElements = {

--- a/visual-tests/index.html
+++ b/visual-tests/index.html
@@ -73,6 +73,8 @@
     <section>
         <h2>Utilities</h2>
         <h3>Chart Layout</h3>
+        <h3>Chart Builder</h3>
+        <div id="chartBuilder"></div>
         <h3>Data Generator</h3>
         <h3>Time interval Width</h3>
         <h3>Value accessor</h3>
@@ -91,6 +93,8 @@
     <script src="test-scripts/scale/d3-time-d3-linear.js"></script>
 
     <script src="test-scripts/series/bar.js"></script>
+
+    <script src="test-scripts/utilities/chartBuilder.js"></script>
 
     <script src="//localhost:35729/livereload.js"></script>
   </body>

--- a/visual-tests/test-scripts/utilities/chartBuilder.js
+++ b/visual-tests/test-scripts/utilities/chartBuilder.js
@@ -1,0 +1,50 @@
+(function(d3, fc) {
+    'use strict';
+
+    var data = fc.utilities.dataGenerator()
+        .seedDate(new Date(2014, 1, 1))
+        .generate(50);
+
+    var chartLayout = fc.utilities.chartLayout();
+    var chartBuilder = fc.utilities.chartBuilder(chartLayout);
+
+    d3.select('#chartBuilder')
+        .call(chartBuilder);
+
+    // Create scale for x axis
+    var dateScale = fc.scale.dateTime()
+        .domain(fc.utilities.extent(data, 'date'))
+        .nice();
+
+    // Create scale for y axis
+    var priceScale = fc.scale.linear()
+        .domain(fc.utilities.extent(data, ['high', 'low']))
+        .nice();
+
+    // Create the axes
+    var dateAxis = d3.svg.axis()
+        .scale(dateScale)
+        .orient('bottom')
+        .ticks(5);
+
+    var priceAxis = d3.svg.axis()
+        .scale(priceScale)
+        .orient('left')
+        .ticks(5);
+
+    var ohlc = fc.series.ohlc()
+        .xScale(dateScale)
+        .yScale(priceScale);
+
+    // add the components to the chart
+    chartBuilder.setAxis('bottom', dateAxis);
+    chartBuilder.setAxis('left', priceAxis);
+    chartBuilder.addToPlotArea([ohlc]);
+
+    // associate the data
+    chartBuilder.setData(data);
+
+    // draw stuff!
+    chartBuilder.render();
+
+})(d3, fc);


### PR DESCRIPTION
This allows the user (and chartBuilder) to data-join their own data - without this chartBuilder doesn't work.

I've also added a new visual test to verify chartBuilder works (yay!)

@jleft - finally remembered why i made that change ;-)