### PR TITLE
Add doc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+doc
 dist
 node_modules
 .*


### PR DESCRIPTION
In its current state, I don't think we should be committing the output of JSDoc.