### PR TITLE
Add fc.utilities.rebind

### DIFF
--- a/components/utilities/rebind.js
+++ b/components/utilities/rebind.js
@@ -1,0 +1,18 @@
+(function(d3, fc) {
+    'use strict';
+
+    fc.utilities.rebind = function(target, source, mappings) {
+        if (typeof(mappings) !== 'object') {
+            return d3.rebind.apply(d3, arguments);
+        }
+        Object.keys(mappings)
+            .forEach(function(targetName) {
+                var method = source[mappings[targetName]];
+                target[targetName] = function() {
+                    var value = method.apply(source, arguments);
+                    return value === source ? target : value;
+                };
+            });
+    };
+
+}(d3, fc));

--- a/components/utilities/rebind.js
+++ b/components/utilities/rebind.js
@@ -1,6 +1,11 @@
 (function(d3, fc) {
     'use strict';
-
+    /**
+     * An overload of the d3.rebind method which allows the source methods
+     * to be rebound to the target with a different name. In the mappings object
+     * keys represent the target method names and values represent the source
+     * object names.
+     */
     fc.utilities.rebind = function(target, source, mappings) {
         if (typeof(mappings) !== 'object') {
             return d3.rebind.apply(d3, arguments);

--- a/tests/utilities/rebindSpec.js
+++ b/tests/utilities/rebindSpec.js
@@ -1,0 +1,47 @@
+(function(d3, fc) {
+    'use strict';
+
+    describe('fc.utilities.rebind', function() {
+
+        var source, target, value;
+
+        beforeEach(function() {
+            value = {};
+            source = {
+                fn: function(arg) {
+                    if (!arguments.length) {
+                        return value;
+                    }
+                    value = arg;
+                    return source;
+                }
+            };
+            target = {};
+        });
+
+        it('should have the same behaviour as d3.rebind', function() {
+            fc.utilities.rebind(target, source, 'fn');
+            expect(target.fn())
+                .toEqual(value);
+
+            var newValue = {};
+            expect(target.fn(newValue))
+                .toEqual(target);
+            expect(target.fn())
+                .toEqual(newValue);
+        });
+
+        it('should allow a mapping object to be used', function() {
+            fc.utilities.rebind(target, source, {'fn2': 'fn'});
+            expect(target.fn2())
+                .toEqual(value);
+
+            var newValue = {};
+            expect(target.fn2(newValue))
+                .toEqual(target);
+            expect(target.fn2())
+                .toEqual(newValue);
+        });
+    });
+
+}(d3, fc));


### PR DESCRIPTION
Allows a mapping object to be specified when rebinding e.g. -
```js
fc.utlities.rebind(target, source, {
  targetName: 'sourceName'
});
```