### PR TITLE
Uses an official release of css-layout

### DIFF
--- a/components/utilities/layout.js
+++ b/components/utilities/layout.js
@@ -1,5 +1,5 @@
 /* globals computeLayout */
-(function(d3, fc) {
+(function(d3, fc, cssLayout) {
     'use strict';
 
 
@@ -110,7 +110,7 @@
                 layoutNodes.style.height = height;
 
                 // use the Facebook CSS goodness
-                computeLayout(layoutNodes);
+                cssLayout.computeLayout(layoutNodes);
 
                 // apply the resultant layout
                 applyLayout(layoutNodes);
@@ -123,4 +123,4 @@
         return layout;
     };
 
-}(d3, fc));
+}(d3, fc, computeLayout));

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "author": "Scott Logic",
   "dependencies": {
-    "css-layout": "git+https://git@github.com/ColinEberhardt/css-layout.git",
+    "css-layout": "^0.0.2",
     "d3": "^3.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
When we first started using Facebook's CSS layout it didn;t have a package.json file. This now exists and they are releasing to npm. This commit updates our repo to use this.