### PR TITLE
Add grunt-contrib-connect, a simple web server for viewing the visual tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,6 +76,19 @@ module.exports = function (grunt) {
             }
         },
 
+        connect: {
+            options: {
+                base: 'visual-tests/dist',
+                useAvailablePort: true
+            },
+            dev: { },
+            keepalive: {
+                options: {
+                    keepalive: true
+                }
+            }
+        },
+
         copy: {
             visualTests: {
                 files: [
@@ -258,9 +271,11 @@ module.exports = function (grunt) {
     grunt.registerTask('build:visual-tests', ['check', 'clean:visualTests', 'copy:visualTests', 'concat:visualTests', 'assemble:visualTests']);
     grunt.registerTask('build:components', ['check', 'concat:dist', 'uglify:dist', 'concat_css:all', 'cssmin:dist', 'jasmine:test']);
     grunt.registerTask('build', ['build:components', 'build:visual-tests']);
+    grunt.registerTask('dev:serve', ['build', 'connect:dev', 'watch']);
     grunt.registerTask('dev', ['build', 'watch']);
     grunt.registerTask('doc', ['clean:doc', 'jsdoc']);
     grunt.registerTask('ci', ['default']);
     grunt.registerTask('test', ['jasmine:test', 'build:visual-tests']);
+    grunt.registerTask('serve', ['connect:keepalive']);
     grunt.registerTask('default', ['build', 'doc']);
 };

--- a/README.md
+++ b/README.md
@@ -61,12 +61,14 @@ The following Grunt tasks, found in `Gruntfile.js`, can be run from the command 
 - `grunt check` - run JSHint and JSCS checks
 - `grunt test` - run unit tests and build the visual tests
 - `grunt watch` - watch the source files and rebuild when a change is saved
+- `grunt serve` - start a web server for viewing the visual tests
 - `grunt dev` - run `grunt build`, then `grunt watch`
+- `grunt dev:serve` - run `grunt build`, then `grunt watch` and start a web server for viewing the visual tests
 - `grunt` - check, test and build the project
 
 ### Visual Tests
 
-The project includes a number of unit tests, however, because these components are visual in nature, unit testing is not enough. This project contains a number of ad-hoc visual tests that are found within the `visual-tests` folder. The visual tests are compiled, via [assemble](http://assemble.io/), to create a simple website. To view this site, run a [static server](https://gist.github.com/willurd/5720255) from the `visual-tests\dist` folder.
+The project includes a number of unit tests, however, because these components are visual in nature, unit testing is not enough. This project contains a number of ad-hoc visual tests that are found within the `visual-tests` folder. The visual tests are compiled, via [assemble](http://assemble.io/), to create a simple website. To view this site, run `grunt serve` or a [static server](https://gist.github.com/willurd/5720255) from the `visual-tests\dist` folder.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,15 +55,18 @@ grunt
 
 ### Grunt Tasks
 
-The following Grunt tasks, found in `Gruntfile.js`, can be run from the command line:
+The following Grunt tasks, found in `Gruntfile.js`, can be run from the command line. The most commonly used tasks to build and develop the project are:
 
 - `grunt build` - generate the project's JavaScript and CSS files in the _dist_ directory (at the root of the project); build the visual tests
+- `grunt dev` - run `grunt build`, then `grunt watch`
+- `grunt dev:serve` - same as `grunt dev` but also starts a web server for viewing the visual tests
+
+Other tasks include:
+
 - `grunt check` - run JSHint and JSCS checks
 - `grunt test` - run unit tests and build the visual tests
 - `grunt watch` - watch the source files and rebuild when a change is saved
 - `grunt serve` - start a web server for viewing the visual tests
-- `grunt dev` - run `grunt build`, then `grunt watch`
-- `grunt dev:serve` - run `grunt build`, then `grunt watch` and start a web server for viewing the visual tests
 - `grunt` - check, test and build the project
 
 ### Visual Tests

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt-concat-css": "^0.3.1",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
+    "grunt-contrib-connect": "^0.10.1",
     "grunt-contrib-copy": "^0.7.0",
     "grunt-contrib-cssmin": "^0.10.0",
     "grunt-contrib-jasmine": "^0.8.2",


### PR DESCRIPTION
My aim is to make it even easier for someone to get a web server started to view the visual tests. If it's not worth the extra bloat, then feel free to close :-).