### PR TITLE
Add seedrandom to support seeded random number generation for the visual tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,22 @@ module.exports = function (grunt) {
             visualTestJsFiles: [
                 'visual-tests/src/**/*.js'
             ],
+            visualTestSiteFiles: [
+                // Index page
+                {
+                    expand: true,
+                    cwd: 'visual-tests/src/site/pages/',
+                    src: ['index.hbs'],
+                    dest: 'visual-tests/dist/'
+                },
+                // Test fixtures
+                {
+                    expand: true,
+                    cwd: 'visual-tests/src/test-fixtures/',
+                    src: ['**/*.hbs'],
+                    dest: 'visual-tests/dist/'
+                }
+            ],
             componentsCssFiles: [
                 'src/**/*.css'
             ],
@@ -33,28 +49,11 @@ module.exports = function (grunt) {
             options: {
                 assets: 'visual-tests/dist/assets',
                 partials: 'visual-tests/src/site/templates/includes/*.hbs',
-                layoutdir: 'visual-tests/src/site/templates/layouts'
+                layoutdir: 'visual-tests/src/site/templates/layouts',
+                layout: 'test.hbs'
             },
             visualTests: {
-                files : [
-                    // Index page
-                    {
-                        expand: true,
-                        cwd: 'visual-tests/src/site/pages/',
-                        src: ['index.hbs'],
-                        dest: 'visual-tests/dist/'
-                    },
-                    // Visual tests
-                    {
-                        expand: true,
-                        cwd: 'visual-tests/src/test-fixtures/',
-                        src: ['**/*.hbs'],
-                        dest: 'visual-tests/dist/'
-                    }
-                ],
-                options: {
-                    layout: 'test.hbs'
-                }
+                files: '<%= meta.visualTestSiteFiles %>'
             }
         },
 
@@ -65,13 +64,6 @@ module.exports = function (grunt) {
             dist: {
                 src: ['src/fc.js', 'src/utilities/*.js', '<%= meta.componentsJsFiles %>'],
                 dest: 'dist/<%= pkg.name %>.js'
-            },
-            visualTests: {
-                options: {
-                    sourceMap: true
-                },
-                src: 'visual-tests/src/site/assets/js/**/*.js',
-                dest: 'visual-tests/dist/assets/index.js',
             }
         },
 
@@ -93,8 +85,8 @@ module.exports = function (grunt) {
                 files: [
                     {
                         expand: true,
-                        cwd: 'visual-tests/src/site/assets/css',
-                        src: ['**/*.css'],
+                        cwd: 'visual-tests/src/site/assets/',
+                        src: ['**/*.css', '**/*.js'],
                         dest: 'visual-tests/dist/assets/',
                     },
                     {
@@ -132,6 +124,12 @@ module.exports = function (grunt) {
                         cwd: 'visual-tests/src/test-fixtures/',
                         src: ['**/*', '!**/*.hbs'],
                         dest: 'visual-tests/dist/',
+                    },
+                    {
+                        expand: true,
+                        cwd: 'node_modules/seedrandom/',
+                        src: ['seedrandom.min.js'],
+                        dest: 'visual-tests/dist/assets/',
                     }
                 ]
             }
@@ -287,7 +285,7 @@ module.exports = function (grunt) {
     grunt.registerTask('check:failOnError', ['jshint:failOnError', 'jscs:failOnError']);
     grunt.registerTask('check:warnOnly', ['jshint:warnOnly', 'jscs:warnOnly']);
     grunt.registerTask('check', ['check:failOnError']);
-    grunt.registerTask('build:visual-tests', ['check', 'clean:visualTests', 'copy:visualTests', 'concat:visualTests', 'assemble:visualTests']);
+    grunt.registerTask('build:visual-tests', ['check', 'clean:visualTests', 'copy:visualTests', 'assemble:visualTests']);
     grunt.registerTask('build:components', ['check', 'clean:dist', 'version', 'concat:dist', 'uglify:dist', 'concat_css:all', 'cssmin:dist', 'jasmine:test']);
     grunt.registerTask('build', ['build:components', 'build:visual-tests']);
     grunt.registerTask('dev:serve', ['build', 'connect:dev', 'watch']);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "grunt-release": "^0.12.0",
     "grunt-version": "^1.0.0",
     "jquery": "^1.11.2",
-    "matchdep": "^0.3.0"
+    "matchdep": "^0.3.0",
+    "seedrandom": "^2.4.0"
   },
   "scripts": {
     "test": "grunt ci"

--- a/visual-tests/src/site/assets/js/seed.js
+++ b/visual-tests/src/site/assets/js/seed.js
@@ -1,0 +1,10 @@
+(function() {
+    'use strict';
+
+    var seed;
+    seed = location.search.split('seed=')[1];
+    if (seed) {
+        // Sets Math.random to a PRNG initialised using the explicit seed
+        Math.seedrandom(seed);
+    }
+}());

--- a/visual-tests/src/site/assets/js/visuals.js
+++ b/visual-tests/src/site/assets/js/visuals.js
@@ -1,9 +1,22 @@
 (function(d3) {
     'use strict';
 
+    var seed = location.search.split('seed=')[1];
+
     var tests = d3.select('#tests')
         .selectAll('.test-fixture')
         .datum(function() { return this.dataset; });
+
+    // Update the links to the test fixtures to include the seed
+    if (seed) {
+        tests.each(function(d) {
+            var test = d3.select(this);
+            test.select('.test-link')
+                .attr('href', function(d) {
+                    return d.visuals + '?seed=' + seed;
+                });
+        });
+    }
 
     // When an iframe is loaded, hide the loading message and automatically adjust its height for its content
     tests.selectAll('.panel-body').select('iframe').on('load', function() {
@@ -25,7 +38,7 @@
             test.select('iframe')
                 .attr('height', 0)
                 .style('display', 'block')
-                .attr('src', d.visuals);
+                .attr('src', seed ? d.visuals + '?seed=' + seed : d.visuals);
         });
     };
 

--- a/visual-tests/src/site/pages/index.hbs
+++ b/visual-tests/src/site/pages/index.hbs
@@ -3,3 +3,6 @@
 layout: index.hbs # Override the default layout for the index page
 notATest: true # Don't show this page in the list in the index page
 ---
+
+<p>To seed the random number generator, used to generate the data in some of the tests, a query string can be added to the URL, like this:</p>
+<pre><code>?seed=yourseed</code></pre>

--- a/visual-tests/src/site/templates/includes/footer.hbs
+++ b/visual-tests/src/site/templates/includes/footer.hbs
@@ -1,6 +1,8 @@
 <script src="{{ assets }}/d3.js"></script>
 <script src="{{ assets }}/Layout.js"></script>
 <script src="{{ assets }}/d3-financial-components.js"></script>
+<script src="{{ assets }}/seedrandom.min.js"></script>
+<script src="{{ assets }}/js/seed.js"></script> 
 {{#unless notATest}}
   {{#each testScripts}}
     <script src="{{ . }}"></script>

--- a/visual-tests/src/site/templates/includes/index-test-list.hbs
+++ b/visual-tests/src/site/templates/includes/index-test-list.hbs
@@ -10,7 +10,7 @@
           <div class="panel panel-default">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <a href="{{ relative ../../../page.dest this.dest }}">
+                <a class="test-link" href="{{ relative ../../../page.dest this.dest }}">
                   {{#if data.title}}
                     {{ data.title }}
                   {{else}}

--- a/visual-tests/src/site/templates/layouts/index.hbs
+++ b/visual-tests/src/site/templates/layouts/index.hbs
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     {{> header }}
-    <link href="{{assets}}/index.css" rel="stylesheet">
+    <link href="{{assets}}/css/index.css" rel="stylesheet">
   </head>
   <body>
     {{> index-top-navbar }}
@@ -23,7 +23,8 @@
       <script src="{{assets}}/jquery.min.js"></script>
       <script src="{{assets}}/bootstrap/js/bootstrap.min.js"></script>
       {{> footer }}
-      <script src="{{assets}}/index.js"></script>
+      <script src="{{assets}}/js/sidebar-nav.js"></script>
+      <script src="{{assets}}/js/visuals.js"></script>
     </footer>
   </body>
 </html>


### PR DESCRIPTION
Many visual tests rely upon `fc.dataGenerator`, which uses `Math.random()` to generate the data values. This is great for producing varied data, but sometimes, when debugging for example, it it is useful to use the same dataset.

This pull request adds [seedrandom](https://github.com/davidbau/seedrandom) as a development dependency, which allows `Math.random()` to be seeded and `fc.dataGenerator` to produce consistent values. This can be included in the visual tests by running `grunt build:visual-tests-debug`.

Does this seem like a good idea? Is this a reasonable approach?