### PR TITLE
Update Travis to run against Node.js 0.12 and io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: node_js
 node_js:
-  - "0.10" # latest stable release
-  - "0.11" # latest development release, may be unstable
+  - "0.10" # stable
+  - "0.11" # development release, may be unstable
+  - "0.12" # stable
+  - "iojs"
 before_install: npm install -g grunt-cli
 install: npm install
 matrix:
   fast_finish: true
   allow_failures:
   - node_js: "0.11"
+  - node_js: "iojs"


### PR DESCRIPTION
As Node.js is now at version 0.12.x, I thought it would be worth Travis running the build against this. I've also added io.js as an allowed failure - this isn't as important, but may be useful/interesting to have.