### PR TITLE
Check if result from Bollinger Bands algorithm is defined before attempting to access its properties

### DIFF
--- a/src/indicators/bollingerBands.js
+++ b/src/indicators/bollingerBands.js
@@ -56,9 +56,11 @@
 
                 data = d3.zip(data, algorithm(data))
                     .map(function(tuple) {
-                        tuple[0].upper = tuple[1].upper;
-                        tuple[0].average = tuple[1].average;
-                        tuple[0].lower = tuple[1].lower;
+                        if (tuple[1]) {
+                            tuple[0].upper = tuple[1].upper;
+                            tuple[0].average = tuple[1].average;
+                            tuple[0].lower = tuple[1].lower;
+                        }
                         return tuple[0];
                     });
 


### PR DESCRIPTION
`tuple[1]`, the result of the Bollinger Bands algorithm, can be `undefined`. When the Bollinger Bands component attempts to access properties of this, a `TypeError` will be thrown.

We should check this to avoid the error. There are several approaches to this; is there are preferred solution?