### PR TITLE
Allow undefinedValue to be specified for slidingWindow

### DIFF
--- a/src/indicators/algorithms/bollingerBands.js
+++ b/src/indicators/algorithms/bollingerBands.js
@@ -6,6 +6,11 @@
         var multiplier = d3.functor(2);
 
         var slidingWindow = fc.indicators.algorithms.slidingWindow()
+            .undefinedValue({
+                upper: undefined,
+                average: undefined,
+                lower: undefined
+            })
             .accumulator(function(values) {
                 var avg = d3.mean(values);
                 var stdDev = d3.deviation(values);

--- a/src/indicators/algorithms/slidingWindow.js
+++ b/src/indicators/algorithms/slidingWindow.js
@@ -3,7 +3,8 @@
 
     fc.indicators.algorithms.slidingWindow = function() {
 
-        var windowSize = d3.functor(10),
+        var undefinedValue = d3.functor(undefined),
+            windowSize = d3.functor(10),
             accumulator = fc.utilities.fn.noop,
             value = fc.utilities.fn.identity;
 
@@ -12,7 +13,7 @@
             var windowData = data.slice(0, size).map(value);
             return data.map(function(d, i) {
                     if (i < size - 1) {
-                        return undefined;
+                        return undefinedValue(d, i);
                     }
                     if (i >= size) {
                         // Treat windowData as FIFO rolling buffer
@@ -23,6 +24,13 @@
                 });
         };
 
+        slidingWindow.undefinedValue = function(x) {
+            if (!arguments.length) {
+                return undefinedValue;
+            }
+            undefinedValue = d3.functor(x);
+            return slidingWindow;
+        };
         slidingWindow.windowSize = function(x) {
             if (!arguments.length) {
                 return windowSize;

--- a/src/indicators/bollingerBands.js
+++ b/src/indicators/bollingerBands.js
@@ -56,11 +56,9 @@
 
                 data = d3.zip(data, algorithm(data))
                     .map(function(tuple) {
-                        if (tuple[1]) {
-                            tuple[0].upper = tuple[1].upper;
-                            tuple[0].average = tuple[1].average;
-                            tuple[0].lower = tuple[1].lower;
-                        }
+                        tuple[0].upper = tuple[1].upper;
+                        tuple[0].average = tuple[1].average;
+                        tuple[0].lower = tuple[1].lower;
                         return tuple[0];
                     });
 

--- a/tests/indicators/algorithms/slidingWindowSpec.js
+++ b/tests/indicators/algorithms/slidingWindowSpec.js
@@ -17,6 +17,14 @@
             expect(slidingWindow([0])).toEqual([undefined]);
         });
 
+        it('should return custom undefinedValue for items less than the window windowSize', function() {
+            var slidingWindow = fc.indicators.algorithms.slidingWindow()
+                .undefinedValue('bob')
+                .accumulator(function() { throw new Error('FAIL'); })
+                .windowSize(2);
+            expect(slidingWindow([0])).toEqual(['bob']);
+        });
+
         it('should call accumulator once for a data array equal in length to the window windowSize', function() {
             var data = [0, 1];
             var accumulatedValue = {};


### PR DESCRIPTION
This allows for the logic in ```series.bollingerBands``` to be cleaned up.