### PR TITLE
Series group elements are now translated, plus negative bar height support

### DIFF
--- a/src/series/bar.js
+++ b/src/series/bar.js
@@ -22,8 +22,7 @@
                 g.enter()
                     .append('path');
 
-                var width = barWidth(data.map(xValueScaled)),
-                    halfWidth = width / 2;
+                var width = barWidth(data.map(xValueScaled));
 
                 var pathGenerator = fc.svg.bar()
                     .width(width);
@@ -36,7 +35,7 @@
                         barTop = yScale(y0 + y1Value(d, i));
 
                     var g = d3.select(this)
-                        .attr('transform', 'translate(' + (x - halfWidth) + ', ' + barTop + ')');
+                        .attr('transform', 'translate(' + x + ', ' + barTop + ')');
 
                     pathGenerator.x(d3.functor(0))
                         .y(d3.functor(0))

--- a/src/series/bar.js
+++ b/src/series/bar.js
@@ -16,34 +16,37 @@
         var bar = function(selection) {
             selection.each(function(data) {
                 var container = d3.select(this);
-                var series = fc.utilities.simpleDataJoin(container, 'bar', data, xValue);
+                var g = fc.utilities.simpleDataJoin(container, 'bar', data, xValue);
 
                 // enter
-                series.enter()
-                    .append('rect');
+                g.enter()
+                    .append('path');
 
                 var width = barWidth(data.map(xValueScaled)),
                     halfWidth = width / 2;
 
-                // update
-                series.select('rect')
-                    .each(function(d, i) {
+                var pathGenerator = fc.svg.bar()
+                    .width(width);
 
-                        var x = xValueScaled(d, i),
-                            y0 = y0Value(d, i),
-                            barBottom = yScale(y0),
-                            barTop = yScale(y0 + y1Value(d, i));
+                g.each(function(d, i) {
 
-                        d3.transition(d3.select(this))
-                            .attr({
-                                x: x - halfWidth,
-                                y: barTop,
-                                width: width,
-                                height: barBottom - barTop
-                            });
-                    });
+                    var x = xValueScaled(d, i),
+                        y0 = y0Value(d, i),
+                        barBottom = yScale(y0),
+                        barTop = yScale(y0 + y1Value(d, i));
 
-                decorate(series);
+                    var g = d3.select(this)
+                        .attr('transform', 'translate(' + (x - halfWidth) + ', ' + barTop + ')');
+
+                    pathGenerator.x(d3.functor(0))
+                        .y(d3.functor(0))
+                        .height(function() { return barBottom - barTop; });
+
+                    g.select('path')
+                        .attr('d', pathGenerator([d]));
+                });
+
+                decorate(g);
             });
         };
 

--- a/src/series/candlestick.js
+++ b/src/series/candlestick.js
@@ -46,7 +46,7 @@
                         })
                         .attr('transform', 'translate(' + x + ', ' + yHigh + ')');
 
-                    pathGenerator.x(function() { return 0; })
+                    pathGenerator.x(d3.functor(0))
                         .open(function() { return yOpen - yHigh; })
                         .high(function() { return yHigh - yHigh; })
                         .low(function() { return yLow - yHigh; })

--- a/src/series/candlestick.js
+++ b/src/series/candlestick.js
@@ -30,6 +30,7 @@
                         .width(barWidth(data.map(xValueScaled)));
 
                 g.each(function(d, i) {
+
                     var yCloseRaw = yCloseValue(d, i),
                         yOpenRaw = yOpenValue(d, i),
                         x = xValueScaled(d, i),
@@ -42,13 +43,14 @@
                         .classed({
                             'up': yCloseRaw > yOpenRaw,
                             'down': yCloseRaw < yOpenRaw
-                        });
+                        })
+                        .attr('transform', 'translate(' + x + ', ' + yHigh + ')');
 
-                    pathGenerator.x(function() { return x; })
-                        .open(function() { return yOpen; })
-                        .high(function() { return yHigh; })
-                        .low(function() { return yLow; })
-                        .close(function() { return yClose; });
+                    pathGenerator.x(function() { return 0; })
+                        .open(function() { return yOpen - yHigh; })
+                        .high(function() { return yHigh - yHigh; })
+                        .low(function() { return yLow - yHigh; })
+                        .close(function() { return yClose - yHigh; });
 
                     g.select('path')
                         .attr('d', pathGenerator([d]));

--- a/src/series/ohlc.js
+++ b/src/series/ohlc.js
@@ -44,7 +44,7 @@
                         })
                         .attr('transform', 'translate(' + x + ', ' + yHigh + ')');
 
-                    pathGenerator.x(function() { return 0; })
+                    pathGenerator.x(d3.functor(0))
                         .open(function() { return yOpen - yHigh; })
                         .high(function() { return yHigh - yHigh; })
                         .low(function() { return yLow - yHigh; })

--- a/src/series/ohlc.js
+++ b/src/series/ohlc.js
@@ -41,13 +41,14 @@
                         .classed({
                             'up': yCloseRaw > yOpenRaw,
                             'down': yCloseRaw < yOpenRaw
-                        });
+                        })
+                        .attr('transform', 'translate(' + x + ', ' + yHigh + ')');
 
-                    pathGenerator.x(function() { return x; })
-                        .open(function() { return yOpen; })
-                        .high(function() { return yHigh; })
-                        .low(function() { return yLow; })
-                        .close(function() { return yClose; });
+                    pathGenerator.x(function() { return 0; })
+                        .open(function() { return yOpen - yHigh; })
+                        .high(function() { return yHigh - yHigh; })
+                        .low(function() { return yLow - yHigh; })
+                        .close(function() { return yClose - yHigh; });
 
                     g.select('path')
                         .attr('d', pathGenerator([d]));

--- a/src/series/point.js
+++ b/src/series/point.js
@@ -21,9 +21,13 @@
                 g.enter()
                     .append('circle');
 
+                g.attr('transform', function(d, i) {
+                    var x = xScale(xValue(d, i)),
+                        y = yScale(yValue(d, i));
+                    return 'translate(' + x + ', ' + y + ')';
+                });
+
                 g.select('circle')
-                    .attr('cx', function(d, i) { return xScale(xValue(d, i)); })
-                    .attr('cy', function(d, i) { return yScale(yValue(d, i)); })
                     .attr('r', radius);
 
                 decorate(g);

--- a/src/series/series.css
+++ b/src/series/series.css
@@ -33,3 +33,9 @@ path.area {
   fill: #9cf;
   fill-opacity: 0.5;
 }
+
+.bar>path {
+  stroke: #06c;
+  fill: #9cf;
+  fill-opacity: 0.5;
+}

--- a/src/svg/bar.js
+++ b/src/svg/bar.js
@@ -19,8 +19,10 @@
                     barHeight = height(d, i),
                     barWidth = width(d, i);
 
+                var halfWidth = barWidth / 2;
+
                 // Move to the start location
-                var body = 'M' + xValue + ',' + yValue +
+                var body = 'M' + (xValue - halfWidth) + ',' + yValue +
                     // Draw the width
                     'h' + barWidth +
                     // Draw to the top

--- a/src/svg/bar.js
+++ b/src/svg/bar.js
@@ -1,0 +1,68 @@
+(function(d3, fc) {
+    'use strict';
+
+    // Renders a bar series as an SVG path based on the given array of datapoints. Each
+    // bar has a fixed width, whilst the x, y and height are obtained from each data
+    // point via the supplied accessor functions.
+    fc.svg.bar = function() {
+
+        var x = function(d, i) { return d.x; },
+            y = function(d, i) { return d.y; },
+            height = function(d, i) { return d.height; },
+            width = d3.functor(3);
+
+        var bar = function(data) {
+
+            return data.map(function(d, i) {
+                var xValue = x(d, i),
+                    yValue = y(d, i),
+                    barHeight = height(d, i),
+                    barWidth = width(d, i);
+
+                // Move to the start location
+                var body = 'M' + xValue + ',' + yValue +
+                    // Draw the width
+                    'h' + barWidth +
+                    // Draw to the top
+                    'V' + barHeight +
+                    // Draw the width
+                    'h' + -barWidth +
+                    // Close the path
+                    'z';
+                return body;
+            })
+            .join('');
+        };
+
+        bar.x = function(_x) {
+            if (!arguments.length) {
+                return x;
+            }
+            x = _x;
+            return bar;
+        };
+        bar.y = function(x) {
+            if (!arguments.length) {
+                return y;
+            }
+            y = x;
+            return bar;
+        };
+        bar.width = function(x) {
+            if (!arguments.length) {
+                return width;
+            }
+            width = d3.functor(x);
+            return bar;
+        };
+        bar.height = function(x) {
+            if (!arguments.length) {
+                return height;
+            }
+            height = x;
+            return bar;
+        };
+        return bar;
+
+    };
+}(d3, fc));

--- a/src/svg/candlestick.js
+++ b/src/svg/candlestick.js
@@ -1,6 +1,9 @@
 (function(d3, fc) {
     'use strict';
 
+    // Renders a candlestick as an SVG path based on the given array of datapoints. Each
+    // candlestick has a fixed width, whilst the x, open, high, low and close positions are
+    // obtained from each point via the supplied accessor functions.
     fc.svg.candlestick = function() {
 
         var x = function(d, i) { return d.date; },

--- a/src/svg/ohlc.js
+++ b/src/svg/ohlc.js
@@ -1,6 +1,9 @@
 (function(d3, fc) {
     'use strict';
 
+    // Renders an OHLC as an SVG path based on the given array of datapoints. Each
+    // OHLC has a fixed width, whilst the x, open, high, low and close positions are
+    // obtained from each point via the supplied accessor functions.
     fc.svg.ohlc = function() {
 
         var x = function(d, i) { return d.date; },

--- a/tests/series/areaSpec.js
+++ b/tests/series/areaSpec.js
@@ -3,7 +3,7 @@
 
     describe('area', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 y0ValueSpy = jasmine.createSpy('y0Value').and.callFake(fc.utilities.fn.identity),

--- a/tests/series/barSpec.js
+++ b/tests/series/barSpec.js
@@ -3,7 +3,7 @@
 
     describe('bar', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 y0ValueSpy = jasmine.createSpy('y0Value').and.callFake(fc.utilities.fn.identity),

--- a/tests/series/candlestickSpec.js
+++ b/tests/series/candlestickSpec.js
@@ -3,7 +3,7 @@
 
     describe('candlestick', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 yOpenValueSpy = jasmine.createSpy('yOpenValue').and.callFake(fc.utilities.fn.identity),

--- a/tests/series/lineSpec.js
+++ b/tests/series/lineSpec.js
@@ -3,7 +3,7 @@
 
     describe('line', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 yValueSpy = jasmine.createSpy('yValue').and.callFake(fc.utilities.fn.identity);

--- a/tests/series/ohlcSpec.js
+++ b/tests/series/ohlcSpec.js
@@ -3,7 +3,7 @@
 
     describe('ohlc', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 yOpenValueSpy = jasmine.createSpy('yOpenValue').and.callFake(fc.utilities.fn.identity),

--- a/tests/series/pointSpec.js
+++ b/tests/series/pointSpec.js
@@ -3,7 +3,7 @@
 
     describe('point', function() {
 
-        it('should invoke data accessors appropriately', function() {
+        it('should invoke data accessors with datum and index', function() {
 
             var xValueSpy = jasmine.createSpy('xValue').and.callFake(fc.utilities.fn.identity),
                 yValueSpy = jasmine.createSpy('yValue').and.callFake(fc.utilities.fn.identity);

--- a/visual-tests/src/test-fixtures/functional/decorate.hbs
+++ b/visual-tests/src/test-fixtures/functional/decorate.hbs
@@ -1,6 +1,6 @@
 ---
 title: Decorate
-description: "Tests decorate by performing a simple specialisation on each series type."
+description: "Tests decorate by performing a simple specialisation on each series type. It also marks the 'origin' of the container which is the parent for each datapoint."
 categories: functional
 tags:
 - decorate

--- a/visual-tests/src/test-fixtures/series/bar-transitions.js
+++ b/visual-tests/src/test-fixtures/series/bar-transitions.js
@@ -6,11 +6,11 @@
         {name: 'Bob', age: 22},
         {name: 'Frank', age: 18},
         {name: 'Jim', age: 18},
-        {name: 'Brian', age: 35},
+        {name: 'Brian', age: -35},
         {name: 'Jane', age: 17},
         {name: 'Katherine', age: 37},
-        {name: 'Alice', age: 22},
-        {name: 'Rachel', age: 27},
+        {name: 'Alice', age: -22},
+        {name: 'Rachel', age: -27},
         {name: 'Jenny', age: 32}
     ];
 
@@ -35,11 +35,11 @@
         .rangePoints([0, width], 1);
 
     var yScale = d3.scale.linear()
-        .domain([0, 40])
+        .domain([-40, 40])
         .range([height - axisHeight, 0]);
 
     var colour = d3.scale.linear()
-        .domain([0, 100])
+        .domain([-50, 50])
         .range(['blue', 'red']);
 
     // Create the axes
@@ -88,7 +88,10 @@
 
         // Update scale domains
         xScale.domain(data.map(function(d) { return d.name; }));
-        yScale.domain([0, d3.max(data, function(d) { return d.age; })]);
+        yScale.domain([
+            d3.min(data, function(d) { return d.age; }),
+            d3.max(data, function(d) { return d.age; })
+        ]);
 
         // Update axes
         axisContainer
@@ -101,9 +104,9 @@
             .call(bar);
     }, 5000);
 
-    // Create a random integer in the range 0-100
+    // Create a random integer in the range -50 - 50
     function randomAge() {
-        return Math.floor(Math.random() * 100);
+        return Math.floor(Math.random() * 100) - 50;
     }
 
 })(d3, fc);

--- a/visual-tests/src/test-fixtures/series/bar.hbs
+++ b/visual-tests/src/test-fixtures/series/bar.hbs
@@ -1,0 +1,11 @@
+---
+title: Bar
+description: "A simple, static bar chart, demonstrating handling of negative values"
+categories: series
+tags:
+- bar
+testScripts:
+- bar.js
+---
+
+<div id="bar"></div>

--- a/visual-tests/src/test-fixtures/series/bar.js
+++ b/visual-tests/src/test-fixtures/series/bar.js
@@ -1,0 +1,42 @@
+(function(d3, fc) {
+    'use strict';
+
+    var data = fc.dataGenerator().startDate(new Date(2014, 1, 1))
+        .filter(d3.functor(true))
+        (50);
+
+    var width = 600, height = 250;
+
+    var container = d3.select('#bar')
+        .append('svg')
+        .attr('width', width)
+        .attr('height', height);
+
+    // Create scale for x axis
+    var dateScale = fc.scale.dateTime()
+        .domain(fc.utilities.extent(data, 'date'))
+        .range([0, width]);
+
+    // offset the close price to give some negative values
+    var extent = fc.utilities.extent(data, ['close']);
+    var offset = extent[0] + (extent[1] - extent[0]) / 2;
+    data.forEach(function(datum) {
+        datum.close = datum.close - offset;
+    });
+
+    // Create scale for y axis
+    var priceScale = d3.scale.linear()
+        .domain(fc.utilities.extent(data, ['close']))
+        .range([height, 0])
+        .nice();
+
+    var bar = fc.series.bar()
+        .xScale(dateScale)
+        .yScale(priceScale);
+
+    // Add it to the chart
+    container.append('g')
+        .datum(data)
+        .call(bar);
+
+})(d3, fc);


### PR DESCRIPTION
Bar series is now rendered using our own bar svg element - Prevously we used a rect, which does not support a negative height. This commit replaces rect with a path, via a path-generator (similar to OHLC / candlestick).

Squashed commits:
[29599f2] ohlc parent group is translated
[585efc5] Candlestick parent group is now translated

See #258

NOTE: This breaks transition support for bar charts (#212), however, as bar was the only series type with support, my feeling is that at this stage it is better to have a more uniform method of rendering series.