### PR TITLE
Fix x-axis in linearTimeSeries

### DIFF
--- a/src/chart/linearTimeSeries.js
+++ b/src/chart/linearTimeSeries.js
@@ -48,7 +48,7 @@
                         position: 'absolute',
                         top: 0,
                         right: 0,
-                        bottom: 0,
+                        bottom: 20,
                         left: 0
                     });
 
@@ -61,15 +61,21 @@
                         position: 'absolute',
                         top: 0,
                         right: 0,
-                        bottom: 0
+                        bottom: 20
                     });
 
-                var xAxisContainer = container.selectAll('g.x-axis')
+                var xAxisContainer = mainContainer.selectAll('g.x-axis')
                     .data([data]);
                 xAxisContainer.enter()
                     .append('g')
                     .attr('class', 'axis x-axis')
-                    .layout('height', 20);
+                    .layout({
+                        height: 20,
+                        position: 'absolute',
+                        right: 0,
+                        bottom: 0,
+                        left: 0
+                    });
 
                 container.layout();
 

--- a/visual-tests/src/test-fixtures/chart/linearTimeSeries.js
+++ b/visual-tests/src/test-fixtures/chart/linearTimeSeries.js
@@ -32,11 +32,6 @@
     chart.plotArea(multi);
 
     d3.select('#linear-time-series')
-        .append('svg')
-        .style({
-            height: '240px',
-            width: '320px'
-        })
         .datum(data)
         .call(chart);
 

--- a/visual-tests/src/test-fixtures/series/multi.hbs
+++ b/visual-tests/src/test-fixtures/series/multi.hbs
@@ -3,7 +3,10 @@ title: Multi
 description: "Demonstrates the Area, Line and Point components."
 categories: series
 tags:
-- multi, area, line, point
+- multi
+- area
+- line
+- point
 testScripts:
 - multi.js
 ---


### PR DESCRIPTION
The linear time series component was appending the x-axis to the `container` (passed into the component), rather than the `mainContainer` (created by the component); this resulted in the x-axis being added outside of the chart's SVG:

![screen shot 2015-05-24 at 16 34 02](https://cloud.githubusercontent.com/assets/2017615/7788442/c6e9d824-0232-11e5-8c77-e9be5f54e868.png)

This pull request appends the x-axis to the appropriate container - `mainContainer` - (so it can be positioned and sized properly, relative to its parent) and adjusts the plot area and y axis container positioning.
