### PR TITLE
Series accessor tests are now more flexible

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,7 +231,8 @@ module.exports = function (grunt) {
                 vendor: [
                     'node_modules/d3/d3.js',
                     'node_modules/css-layout/src/Layout.js'
-                ]
+                ],
+                helpers: 'tests/beforeEachSpec.js'
             },
             test: {
                 src: ['dist/*.js'],

--- a/tests/beforeEachSpec.js
+++ b/tests/beforeEachSpec.js
@@ -9,8 +9,8 @@ beforeEach(function() {
                 .forEach(function(call, i) {
                     // check that the first argument is always an element from the data array
                     expect(data.indexOf(call.args[0])).not.toEqual(-1);
-                    // check that the second argument is awlays an integer
-                    expect(call.args[1]).toEqual(parseInt(Number(call.args[1])));
+                    // check that the second argument is always an integer
+                    expect(call.args[1]).toEqual(Math.round(call.args[1]));
                 });
         }
     };

--- a/tests/beforeEachSpec.js
+++ b/tests/beforeEachSpec.js
@@ -1,0 +1,17 @@
+beforeEach(function() {
+    'use strict';
+
+    this.utils = {
+        // verifies that each time a property accessor is called that the first arg is a datapoint
+        // from the given array of data, and that the second arg is an integer
+        verifyAccessorCalls: function(spy, data) {
+            spy.calls.all()
+                .forEach(function(call, i) {
+                    // check that the first argument is always an element from the data array
+                    expect(data.indexOf(call.args[0])).not.toEqual(-1);
+                    // check that the second argument is awlays an integer
+                    expect(call.args[1]).toEqual(parseInt(Number(call.args[1])));
+                });
+        }
+    };
+});

--- a/tests/series/areaSpec.js
+++ b/tests/series/areaSpec.js
@@ -22,28 +22,16 @@
                 .call(area);
 
             expect(xValueSpy.calls.count()).toEqual(data.length);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
 
             // the defined call also invokes the y value accessors,
             // therefore they are invoked twice for each data point
 
             expect(y0ValueSpy.calls.count()).toEqual(data.length * 2);
-            y0ValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[Math.floor(i / 2)]);
-                    expect(call.args[1]).toEqual(Math.floor(i / 2));
-                });
+            this.utils.verifyAccessorCalls(y0ValueSpy, data);
 
             expect(y1ValueSpy.calls.count()).toEqual(data.length * 2);
-            y1ValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[Math.floor(i / 2)]);
-                    expect(call.args[1]).toEqual(Math.floor(i / 2));
-                });
+            this.utils.verifyAccessorCalls(y1ValueSpy, data);
         });
     });
 

--- a/tests/series/barSpec.js
+++ b/tests/series/barSpec.js
@@ -16,35 +16,23 @@
 
             var element = document.createElement('svg'),
                 container = d3.select(element),
-                data = [0, 2, 4, 8, 16];
+                data = [0.1, 2.2, 4.3, 8.4, 16.5];
 
             container.datum(data)
                 .call(bar);
 
             // the data join and the bar width calculations also invoke
-            // the x value accessor, therefore it is invoked three times
+            // the x value accessor, therefore it is invoked four times
             // for each data point
-
             expect(xValueSpy.calls.count()).toEqual(data.length * 4);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i % data.length]);
-                    expect(call.args[1]).toEqual(i % data.length);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
+
 
             expect(y0ValueSpy.calls.count()).toEqual(data.length * 4);
-            expect(y0ValueSpy.calls.argsFor(0)).toEqual([0, 0]);
-            expect(y0ValueSpy.calls.argsFor(1)).toEqual([2, 1]);
-            expect(y0ValueSpy.calls.argsFor(2)).toEqual([4, 2]);
-            expect(y0ValueSpy.calls.argsFor(3)).toEqual([8, 3]);
-            expect(y0ValueSpy.calls.argsFor(4)).toEqual([16, 4]);
+            this.utils.verifyAccessorCalls(y0ValueSpy, data);
 
             expect(y1ValueSpy.calls.count()).toEqual(data.length * 2);
-            expect(y1ValueSpy.calls.argsFor(0)).toEqual([0, 0]);
-            expect(y1ValueSpy.calls.argsFor(2)).toEqual([2, 1]);
-            expect(y1ValueSpy.calls.argsFor(4)).toEqual([4, 2]);
-            expect(y1ValueSpy.calls.argsFor(6)).toEqual([8, 3]);
-            expect(y1ValueSpy.calls.argsFor(8)).toEqual([16, 4]);
+            this.utils.verifyAccessorCalls(y1ValueSpy, data);
         });
     });
 

--- a/tests/series/candlestickSpec.js
+++ b/tests/series/candlestickSpec.js
@@ -20,7 +20,7 @@
 
             var element = document.createElement('svg'),
                 container = d3.select(element),
-                data = [0, 2, 4, 8, 16];
+                data = [0.1, 2.2, 4.3, 8.4, 16.5];
 
             container.datum(data)
                 .call(candlestick);
@@ -30,39 +30,19 @@
             // for each data point
 
             expect(xValueSpy.calls.count()).toEqual(data.length * 3);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i % data.length]);
-                    expect(call.args[1]).toEqual(i % data.length);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yOpenValueSpy.calls.count()).toEqual(data.length);
-            yOpenValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yOpenValueSpy, data);
 
             expect(yHighValueSpy.calls.count()).toEqual(data.length);
-            yHighValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yHighValueSpy, data);
 
             expect(yLowValueSpy.calls.count()).toEqual(data.length);
-            yLowValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yLowValueSpy, data);
 
             expect(yCloseValueSpy.calls.count()).toEqual(data.length);
-            yCloseValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yCloseValueSpy, data);
         });
     });
 

--- a/tests/series/lineSpec.js
+++ b/tests/series/lineSpec.js
@@ -14,27 +14,19 @@
 
             var element = document.createElement('svg'),
                 container = d3.select(element),
-                data = [0, 2, 4, 8, 16];
+                data = [0.2, 2.4, 4.5, 8.6, 16.7];
 
             container.datum(data)
                 .call(line);
 
             expect(xValueSpy.calls.count()).toEqual(data.length);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
 
             // the defined call also invokes the y value accessor,
             // therefore it is invoked twice for each data point
 
             expect(yValueSpy.calls.count()).toEqual(data.length * 2);
-            yValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[Math.floor(i / 2)]);
-                    expect(call.args[1]).toEqual(Math.floor(i / 2));
-                });
+            this.utils.verifyAccessorCalls(yValueSpy, data);
         });
     });
 

--- a/tests/series/ohlcSpec.js
+++ b/tests/series/ohlcSpec.js
@@ -20,7 +20,7 @@
 
             var element = document.createElement('svg'),
                 container = d3.select(element),
-                data = [0, 2, 4, 8, 16];
+                data = [0.2, 2.4, 4.3, 8.2, 16.3];
 
             container.datum(data)
                 .call(ohlc);
@@ -30,39 +30,19 @@
             // for each data point
 
             expect(xValueSpy.calls.count()).toEqual(data.length * 3);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i % data.length]);
-                    expect(call.args[1]).toEqual(i % data.length);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yOpenValueSpy.calls.count()).toEqual(data.length);
-            yOpenValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yOpenValueSpy, data);
 
             expect(yHighValueSpy.calls.count()).toEqual(data.length);
-            yHighValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yHighValueSpy, data);
 
             expect(yLowValueSpy.calls.count()).toEqual(data.length);
-            yLowValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yLowValueSpy, data);
 
             expect(yCloseValueSpy.calls.count()).toEqual(data.length);
-            yCloseValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yCloseValueSpy, data);
         });
     });
 

--- a/tests/series/pointSpec.js
+++ b/tests/series/pointSpec.js
@@ -14,7 +14,7 @@
 
             var element = document.createElement('svg'),
                 container = d3.select(element),
-                data = [0, 2, 4, 8, 16];
+                data = [0.1, 2.5, 4.3, 8.4, 16.4];
 
             container.datum(data)
                 .call(point);
@@ -22,18 +22,10 @@
             // the data join also invokes the x value accessor,
             // therefore it is invoked twice for each data point
             expect(xValueSpy.calls.count()).toEqual(data.length * 2);
-            xValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i % data.length]);
-                    expect(call.args[1]).toEqual(i % data.length);
-                });
+            this.utils.verifyAccessorCalls(xValueSpy, data);
 
             expect(yValueSpy.calls.count()).toEqual(data.length);
-            yValueSpy.calls.all()
-                .forEach(function(call, i) {
-                    expect(call.args[0]).toEqual(data[i]);
-                    expect(call.args[1]).toEqual(i);
-                });
+            this.utils.verifyAccessorCalls(yValueSpy, data);
         });
     });
 


### PR DESCRIPTION
See comment here: https://github.com/ScottLogic/d3-financial-components/pull/376#issuecomment-106623087

The tests only ensure that the first arg of an accessor is an element from the data array and that the second is an integer. They are no longer tightly coupled to the order and number of invocations of the accessors.