### PR TITLE
Removed version number from fc.js

### DIFF
--- a/src/fc.js
+++ b/src/fc.js
@@ -1,9 +1,6 @@
 (function() {
     'use strict';
 
-    // Needs to be defined like this so that the grunt task can update it
-    var version = '0.2.0';
-
     // Crazyness to get a strict mode compliant reference to the global object
     var global = null;
     /* jshint ignore:start */
@@ -11,7 +8,6 @@
     /* jshint ignore:end */
 
     global.fc = {
-        version: version,
         charts: {},
         indicators: {
             algorithms: {


### PR DESCRIPTION
No version number is better than the wrong version number! see: #370
I've left the versioning grunt task in there as a reminder to re-instate this code once the related issue is resolved.