### PR TITLE
Annotation refactor

### DIFF
--- a/src/tools/horizontalLine.js
+++ b/src/tools/horizontalLine.js
@@ -1,7 +1,7 @@
 (function(d3, fc) {
     'use strict';
 
-    fc.tools.horizontalLineAnnotation = function() {
+    fc.tools.horizontalLine = function() {
 
         var xScale = d3.time.scale(),
             yScale = d3.scale.linear(),
@@ -10,38 +10,38 @@
             label = yValue,
             decorate = fc.utilities.fn.noop;
 
-        var horizontalLineAnnotation = function(selection) {
+        var horizontalLine = function(selection) {
             selection.each(function(data) {
                 var xScaleRange = xScale.range(),
-                    y = function(d) { return yScale(yValue(d)); };
+                    containerTransform = function(d) {
+                        return 'translate(' + xScaleRange[0] + ', ' + yScale(yValue(d)) + ')';
+                    },
+                    xScaleWidth = xScaleRange[1] - xScaleRange[0];
 
                 var container = d3.select(this);
 
-                // Create a group for each horizontalLineAnnotation
+                // Create a group for each horizontalLine
                 var g = fc.utilities.simpleDataJoin(container, 'annotation', data, keyValue);
 
                 // create the outer container and line
-                var enter = g.enter();
+                var enter = g.enter()
+                    .attr('transform', containerTransform);
                 enter.append('line')
-                    .attr('x2', xScaleRange[1] - xScaleRange[0]);
+                    .attr('x2', xScaleWidth);
                 // create an empty left container
                 enter.append('g')
                     .classed('left-handle', true);
                 // create a right container with a text label
                 enter.append('g')
                     .classed('right-handle', true)
-                    .attr('transform', function(d) {
-                        return 'translate(' + (xScaleRange[1] - xScaleRange[0]) + ', 0)';
-                    })
+                    .attr('transform', 'translate(' + xScaleWidth + ', 0)')
                     .append('text')
-                    .attr('transform', 'translate(-5, -5)');
+                    .attr({x: -5, y: -5});
 
                 // Update
 
                 // translate the parent container to the left hand edge of the annotation
-                g.attr('transform', function(d) {
-                    return 'translate(' + xScaleRange[0] + ', ' + y(d) + ')';
-                });
+                g.attr('transform', containerTransform);
 
                 // Update the text label
                 g.select('text')
@@ -51,50 +51,50 @@
             });
         };
 
-        horizontalLineAnnotation.xScale = function(x) {
+        horizontalLine.xScale = function(x) {
             if (!arguments.length) {
                 return xScale;
             }
             xScale = x;
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
-        horizontalLineAnnotation.yScale = function(x) {
+        horizontalLine.yScale = function(x) {
             if (!arguments.length) {
                 return yScale;
             }
             yScale = x;
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
-        horizontalLineAnnotation.yValue = function(x) {
+        horizontalLine.yValue = function(x) {
             if (!arguments.length) {
                 return yValue;
             }
             yValue = d3.functor(x);
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
-        horizontalLineAnnotation.keyValue = function(x) {
+        horizontalLine.keyValue = function(x) {
             if (!arguments.length) {
                 return keyValue;
             }
             keyValue = d3.functor(x);
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
-        horizontalLineAnnotation.label = function(x) {
+        horizontalLine.label = function(x) {
             if (!arguments.length) {
                 return label;
             }
             label = d3.functor(x);
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
-        horizontalLineAnnotation.decorate = function(x) {
+        horizontalLine.decorate = function(x) {
             if (!arguments.length) {
                 return decorate;
             }
             decorate = x;
-            return horizontalLineAnnotation;
+            return horizontalLine;
         };
 
-        return horizontalLineAnnotation;
+        return horizontalLine;
     };
 
 }(d3, fc));

--- a/src/tools/horizontalLineAnnotation.js
+++ b/src/tools/horizontalLineAnnotation.js
@@ -1,7 +1,7 @@
 (function(d3, fc) {
     'use strict';
 
-    fc.tools.annotation = function() {
+    fc.tools.horizontalLineAnnotation = function() {
 
 
         var xScale = d3.time.scale(),
@@ -9,17 +9,16 @@
             yValue = fc.utilities.fn.identity,
             keyValue = fc.utilities.fn.index,
             label = yValue,
-            padding = d3.functor(2),
             decorate = fc.utilities.fn.noop;
 
-        var annotation = function(selection) {
+        var horizontalLineAnnotation = function(selection) {
             selection.each(function(data) {
                 var xScaleRange = xScale.range(),
                     y = function(d) { return yScale(yValue(d)); };
 
                 var container = d3.select(this);
 
-                // Create a group for each annotation
+                // Create a group for each horizontalLineAnnotation
                 var g = fc.utilities.simpleDataJoin(container, 'annotation', data, keyValue);
 
                 // Added the required elements - each annotation consists of a line and text label
@@ -34,68 +33,60 @@
                     .attr('x2', xScaleRange[1])
                     .attr('y2', y);
 
-                // Update the text label
-                var paddingValue = padding.apply(this, arguments);
+                // Update the text label - TODO: Add padding
                 g.select('text')
-                    .attr('x', xScaleRange[1] - paddingValue)
-                    .attr('y', function(d) { return y(d) - paddingValue; })
+                    .attr('x', xScaleRange[1])
+                    .attr('y', function(d) { return y(d); })
                     .text(label);
 
                 decorate(g);
             });
         };
 
-        annotation.xScale = function(x) {
+        horizontalLineAnnotation.xScale = function(x) {
             if (!arguments.length) {
                 return xScale;
             }
             xScale = x;
-            return annotation;
+            return horizontalLineAnnotation;
         };
-        annotation.yScale = function(x) {
+        horizontalLineAnnotation.yScale = function(x) {
             if (!arguments.length) {
                 return yScale;
             }
             yScale = x;
-            return annotation;
+            return horizontalLineAnnotation;
         };
-        annotation.yValue = function(x) {
+        horizontalLineAnnotation.yValue = function(x) {
             if (!arguments.length) {
                 return yValue;
             }
             yValue = d3.functor(x);
-            return annotation;
+            return horizontalLineAnnotation;
         };
-        annotation.keyValue = function(x) {
+        horizontalLineAnnotation.keyValue = function(x) {
             if (!arguments.length) {
                 return keyValue;
             }
             keyValue = d3.functor(x);
-            return annotation;
+            return horizontalLineAnnotation;
         };
-        annotation.label = function(x) {
+        horizontalLineAnnotation.label = function(x) {
             if (!arguments.length) {
                 return label;
             }
             label = d3.functor(x);
-            return annotation;
+            return horizontalLineAnnotation;
         };
-        annotation.padding = function(x) {
-            if (!arguments.length) {
-                return padding;
-            }
-            padding = d3.functor(x);
-            return annotation;
-        };
-        annotation.decorate = function(x) {
+        horizontalLineAnnotation.decorate = function(x) {
             if (!arguments.length) {
                 return decorate;
             }
             decorate = x;
-            return annotation;
+            return horizontalLineAnnotation;
         };
 
-        return annotation;
+        return horizontalLineAnnotation;
     };
 
 }(d3, fc));

--- a/src/tools/horizontalLineAnnotation.js
+++ b/src/tools/horizontalLineAnnotation.js
@@ -3,7 +3,6 @@
 
     fc.tools.horizontalLineAnnotation = function() {
 
-
         var xScale = d3.time.scale(),
             yScale = d3.scale.linear(),
             yValue = fc.utilities.fn.identity,
@@ -21,22 +20,31 @@
                 // Create a group for each horizontalLineAnnotation
                 var g = fc.utilities.simpleDataJoin(container, 'annotation', data, keyValue);
 
-                // Added the required elements - each annotation consists of a line and text label
+                // create the outer container and line
                 var enter = g.enter();
-                enter.append('line');
-                enter.append('text');
+                enter.append('line')
+                    .attr('x2', xScaleRange[1] - xScaleRange[0]);
+                // create an empty left container
+                enter.append('g')
+                    .classed('left-handle', true);
+                // create a right container with a text label
+                enter.append('g')
+                    .classed('right-handle', true)
+                    .attr('transform', function(d) {
+                        return 'translate(' + (xScaleRange[1] - xScaleRange[0]) + ', 0)';
+                    })
+                    .append('text')
+                    .attr('transform', 'translate(-5, -5)');
 
-                // Update the line
-                g.select('line')
-                    .attr('x1', xScaleRange[0])
-                    .attr('y1', y)
-                    .attr('x2', xScaleRange[1])
-                    .attr('y2', y);
+                // Update
 
-                // Update the text label - TODO: Add padding
+                // translate the parent container to the left hand edge of the annotation
+                g.attr('transform', function(d) {
+                    return 'translate(' + xScaleRange[0] + ', ' + y(d) + ')';
+                });
+
+                // Update the text label
                 g.select('text')
-                    .attr('x', xScaleRange[1])
-                    .attr('y', function(d) { return y(d); })
                     .text(label);
 
                 decorate(g);

--- a/src/tools/tools.css
+++ b/src/tools/tools.css
@@ -53,7 +53,7 @@
   stroke-width: 1;
   stroke-dasharray: 3, 3;
 }
-.annotation>text {
+.annotation text {
   font: 10px sans-serif;
   text-anchor: end;
 }

--- a/visual-tests/src/test-fixtures/tools/annotation.js
+++ b/visual-tests/src/test-fixtures/tools/annotation.js
@@ -51,8 +51,11 @@
         .decorate(function(selection) {
             selection.select('line')
                 .style('stroke', 'red');
-            selection.select('text')
-                .attr('x', dateScale.range()[1]);
+            selection.enter()
+                .select('g.left-handle')
+                .append('circle')
+                .attr('r', 5)
+                .attr('fill', 'black');
         })
         .label(function(d) {
             return 'Animated: ' + d3.format('.3f')(d);

--- a/visual-tests/src/test-fixtures/tools/annotation.js
+++ b/visual-tests/src/test-fixtures/tools/annotation.js
@@ -33,21 +33,19 @@
         .call(ohlc);
 
     // Create the annotations
-    var annotation = fc.tools.annotation()
+    var annotation = fc.tools.horizontalLineAnnotation()
         .xScale(dateScale)
-        .yScale(priceScale)
-        .padding(10);
+        .yScale(priceScale);
 
-    var lastCloseAnnotation = fc.tools.annotation()
+    var lastCloseAnnotation = fc.tools.horizontalLineAnnotation()
         .yValue(function(d) { return d.close; })
         .xScale(dateScale)
         .yScale(priceScale)
-        .padding(7)
         .label(function(d) {
             return '[Static] Last close: ' + d3.format('.6f')(d.close);
         });
 
-    var annotationDecimal = fc.tools.annotation()
+    var annotationDecimal = fc.tools.horizontalLineAnnotation()
         .xScale(dateScale)
         .yScale(priceScale)
         .decorate(function(selection) {

--- a/visual-tests/src/test-fixtures/tools/annotation.js
+++ b/visual-tests/src/test-fixtures/tools/annotation.js
@@ -13,7 +13,7 @@
     // Create scale for x axis
     var dateScale = fc.scale.dateTime()
         .domain(fc.utilities.extent(data, 'date'))
-        .range([0, width])
+        .range([100, width])
         .nice();
 
     // Create scale for y axis
@@ -33,11 +33,11 @@
         .call(ohlc);
 
     // Create the annotations
-    var annotation = fc.tools.horizontalLineAnnotation()
+    var annotation = fc.tools.horizontalLine()
         .xScale(dateScale)
         .yScale(priceScale);
 
-    var lastCloseAnnotation = fc.tools.horizontalLineAnnotation()
+    var lastCloseAnnotation = fc.tools.horizontalLine()
         .yValue(function(d) { return d.close; })
         .xScale(dateScale)
         .yScale(priceScale)
@@ -45,7 +45,7 @@
             return '[Static] Last close: ' + d3.format('.6f')(d.close);
         });
 
-    var annotationDecimal = fc.tools.horizontalLineAnnotation()
+    var annotationDecimal = fc.tools.horizontalLine()
         .xScale(dateScale)
         .yScale(priceScale)
         .decorate(function(selection) {


### PR DESCRIPTION
The line annotation creates the following structure:

![screen shot 2015-06-09 at 15 31 12](https://cloud.githubusercontent.com/assets/1098110/8060341/9e79baee-0ebc-11e5-847c-c25363342da2.png)

This makes it easier to add ' handles' or other decoration on the left or right-hand size of the annotation.