### PR TITLE
Removed multi series data join key function

### DIFF
--- a/src/series/multi.js
+++ b/src/series/multi.js
@@ -12,8 +12,7 @@
             .children(true)
             .selector('g.multi')
             .element('g')
-            .attrs({'class': 'multi'})
-            .key(function(d) { return d.__series__; });
+            .attrs({'class': 'multi'});
 
         var multi = function(selection) {
 


### PR DESCRIPTION
Fixes #410 

The data-join key function must return a string (internally data-join uses d3.map, which coerces key values to strings). The functions that were being used as the keys for the multi-series were being coerced to strings, hence you could only add one instance of each series / function type.

I've removed the key function, not ideal, but I can't see an elegant way of creating a string key for each series.